### PR TITLE
#EGE-148: Add alpha channel option in get-color functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
    "scripts": {
       "test": "node-sass --include-path scss index.scss main.css && rm -drf main.css",
       "replace": "json -I -f package.json -e",
-      "sass-lint": "sass-lint -c .sass-lint.yml ./**/*.scss -v -q -i vendors/_sanitize.scss"
+      "sass-lint": "sass-lint -c .sass-lint.yml ./settings/*.scss ./utils/*.scss -v -q"
    },
    "author": "Stratio",
    "repository": {

--- a/utils/_colors.scss
+++ b/utils/_colors.scss
@@ -57,7 +57,7 @@
    }
 }
 
-@function egeo-get-color($color, $rgb: false, $alpha: 0) {
+@function egeo-get-color($color, $rgb: false, $alpha: 1) {
    $result: #000;
 
    @if ($rgb) {
@@ -88,6 +88,12 @@
                @return -1;
             }
          }
+      }
+   }
+
+   @if ($alpha > 1) {
+      @if egeo-log('@egeo-get-color::Alpha channel cannot be more than 1. Value::' + $alpha, $egeo-log-error) {
+         @return -1;
       }
    }
 

--- a/utils/_colors.scss
+++ b/utils/_colors.scss
@@ -57,7 +57,7 @@
    }
 }
 
-@function egeo-get-color($color, $rgb: false) {
+@function egeo-get-color($color, $rgb: false, $alpha: 0) {
    $result: #000;
 
    @if ($rgb) {
@@ -67,27 +67,32 @@
          @if type-of($egeo-colors) == 'map' {
             @if map-has-key($egeo-colors, $color) {
                $result: map-get($egeo-colors, $color);
+
             } @else {
                @if function-exists(egeo-log) {
-                  @if egeo-log('@egeo-get-color::The color #{$color} not exist in $egeo-colors.', $egeo-log-warn) {
+                  @if egeo-log('@egeo-get-color::The color #{$color} not exist in $egeo-colors.', $egeo-log-error) {
                      @return -1;
                   }
                }
             }
          } @else {
             @if function-exists(egeo-log) {
-               @if egeo-log('@egeo-get-color::The $egeo-colors variable is not a Sass map.', $egeo-log-warn) {
+               @if egeo-log('@egeo-get-color::The $egeo-colors variable is not a Sass map.', $egeo-log-error) {
                   @return -1;
                }
             }
          }
       } @else {
          @if function-exists(egeo-log) {
-            @if egeo-log('@egeo-get-color::The Sass map $egeo-colors is not defined.', $egeo-log-warn) {
+            @if egeo-log('@egeo-get-color::The Sass map $egeo-colors is not defined.', $egeo-log-error) {
                @return -1;
             }
          }
       }
+   }
+
+   @if ($alpha > 0) {
+      $result: rgba(red($result), green($result), blue($result), $alpha);
    }
 
    @return $result;
@@ -96,7 +101,8 @@
 @function egeo-get-rgb-color($color) {
    $result: #000;
 
-   @if egeo-log('@egeo-get-rgb-color::Get color #{$color} from RGB.', $egeo-log-warn) {
+   @if egeo-log('@egeo-get-rgb-color::Get color #{$color} from RGB.') {
+      $result: #000;
    }
 
    @if global-variable-exists(egeo-rgb-colors) {
@@ -105,21 +111,21 @@
             $result: map-get($egeo-rgb-colors, $color);
          } @else {
             @if function-exists(egeo-log) {
-               @if egeo-log('@egeo-get-rgb-color::The color #{$color} not exist in $egeo-rgb-colors.', $egeo-log-warn) {
+               @if egeo-log('@egeo-get-rgb-color::The color #{$color} not exist in $egeo-rgb-colors.', $egeo-log-error) {
                   @return -1;
                }
             }
          }
       } @else {
          @if function-exists(egeo-log) {
-            @if egeo-log('@egeo-get-rgb-color::The $egeo-rgb-colors variable is not a Sass map.', $egeo-log-warn) {
+            @if egeo-log('@egeo-get-rgb-color::The $egeo-rgb-colors variable is not a Sass map.', $egeo-log-error) {
                @return -1;
             }
          }
       }
    } @else {
       @if function-exists(egeo-log) {
-         @if egeo-log('@egeo-get-rgb-color::The Sass map $egeo-rgb-colors is not defined.', $egeo-log-warn) {
+         @if egeo-log('@egeo-get-rgb-color::The Sass map $egeo-rgb-colors is not defined.', $egeo-log-error) {
             @return -1;
          }
       }


### PR DESCRIPTION
The sass-lint will fail due to a recognized bug of sass-lint library. The color functions such as red(), green() or blue() are recognized as color values not as functions.