### PR TITLE
fix(sanitize): Remove the always visible scrollbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.3.0 (upcoming)
 
-* Pending changelog
+* Remove vertical scrollbars always visible in the Sanitize configuration
 
 ## 1.2.0 (March 16, 2017)
 

--- a/vendors/_sanitize.scss
+++ b/vendors/_sanitize.scss
@@ -8,8 +8,13 @@
 // focused in the last versions of browsers, including mobile, and even new ones
 // like [Microsoft Edge](https://www.microsoft.com/es-es/windows/microsoft-edge) and much more.
 //
-// By Default, Sanitize is active and will be included in the final CSS generated.
-// However, we can avoid the use of Sanitize putting to `false` the variable `$egeo-sanitize`.
+// By Default, Sanitize is inactive and will not be included in the final CSS generated.
+//
+// We can active the use of Sanitize putting to `true` the variable `$egeo-sanitize` before the
+// import of the library.
+//
+// This is a modified version over the v2.0.0 so keep in mind that could be differences with the 
+// original one.
 //
 // | Variable                                                   | Default value                                     | Description                                                        |
 // | ---------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------ |
@@ -62,7 +67,6 @@ $egeo-sanitize: false !default;
 
 	:root {
 		-ms-overflow-style: -ms-autohiding-scrollbar; // Edge 12+, Internet Explorer 11-
-		overflow-y: scroll; // All browsers without overlaying scrollbars
 		-webkit-text-size-adjust: 100%; // iOS 8+
 	}
 


### PR DESCRIPTION
Sanitize adds code to set vertical scrollbar of the browser always visible. We remove this behavior.

Close #47

## TYPE
- Bugfix

### Documentation
- [x] Have changelog.md updated

### Other observations
-

### Post-review reminder
- Remember reviewer approve changes inside the Files Changed tab (Review changes dropdown)
- Squash commits
- Release version in case of breaking changes and notify of all front
